### PR TITLE
Fix double quotes issue on windows

### DIFF
--- a/crystal.bat
+++ b/crystal.bat
@@ -1,2 +1,2 @@
 @echo off
-bash.exe -c 'CRYSTAL_PATH="%CRYSTAL_PATH%" crystal %*'
+bash.exe -c "CRYSTAL_PATH=\"%CRYSTAL_PATH%\" crystal %*"


### PR DESCRIPTION
```
crystal: -c: line 0: unexpected EOF while looking for matching `''
crystal: -c: line 1: syntax error: unexpected end of file
```